### PR TITLE
Fixed for C++23

### DIFF
--- a/mp/src/public/tier0/threadtools.h
+++ b/mp/src/public/tier0/threadtools.h
@@ -866,7 +866,7 @@ private:
 	MUTEX_TYPE &m_lock;
 
 	// Disallow copying
-	CAutoLockT<MUTEX_TYPE>( const CAutoLockT<MUTEX_TYPE> & );
+	CAutoLockT( const CAutoLockT<MUTEX_TYPE> & );
 	CAutoLockT<MUTEX_TYPE> &operator=( const CAutoLockT<MUTEX_TYPE> & );
 };
 

--- a/mp/src/public/tier1/datamanager.h
+++ b/mp/src/public/tier1/datamanager.h
@@ -133,10 +133,10 @@ class CDataManager : public CDataManagerBase
 	typedef CDataManagerBase BaseClass;
 public:
 
-	CDataManager<STORAGE_TYPE, CREATE_PARAMS, LOCK_TYPE, MUTEX_TYPE>( unsigned int size = (unsigned)-1 ) : BaseClass(size) {}
+	CDataManager( unsigned int size = (unsigned)-1 ) : BaseClass(size) {}
 	
 
-	~CDataManager<STORAGE_TYPE, CREATE_PARAMS, LOCK_TYPE, MUTEX_TYPE>()
+	~CDataManager()
 	{
 		// NOTE: This must be called in all implementations of CDataManager
 		FreeAllLists();


### PR DESCRIPTION
That style of template typing/whatever was deprecated in c++17. This fixes it (No negative effects found just a style difference)